### PR TITLE
feat(build): Build binary from docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,2 @@
-.*
-vendor
 Dockerfile
-Makefile
 README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,17 @@
+# Multistage build
+# #1 stage to build the Go binary
+FROM golang AS builder
+WORKDIR /usr/src/app
+COPY . .
+RUN make build
+
+# #2 stage copies binary from #1 + entrypoint
 FROM        quay.io/prometheus/busybox:latest
 MAINTAINER  kwanhur <huang_hua2012@163.com>
 
-COPY ipvs-exporter  /usr/bin/ipvs-exporter
+COPY --from=builder /usr/src/app/ipvs-exporter /usr/bin/ipvs-exporter
 COPY docker-entrypoint.sh /bin/docker-entrypoint.sh
+RUN chmod 755 /bin/docker-entrypoint.sh
 
 ENV METRICS_ENDPOINT "/metrics"
 ENV METRICS_ADDR ":9911"


### PR DESCRIPTION
By adding a build stage in the Dockerfile, we can now build GO binary from container and avoid building from laptop.